### PR TITLE
   Separate endpoints: Split user-specific actions into dedicated controller

### DIFF
--- a/src/main/java/com/mjcarvajalq/sales_metrics_api/controllers/OutreachActionController.java
+++ b/src/main/java/com/mjcarvajalq/sales_metrics_api/controllers/OutreachActionController.java
@@ -31,12 +31,9 @@ public class OutreachActionController {
     }
 
     @GetMapping
-    public List<OutreachActionDTO> listActions(@RequestParam(required = false) Long userId){
-        if (userId != null) {
-            return outreachActionService.getActionsByUserId(userId);
-        } else {
-            return outreachActionService.getAllActions();
-        }
+    public ResponseEntity<List<OutreachActionDTO>> getAllActions() {
+        List<OutreachActionDTO> actions = outreachActionService.getAllActions();
+        return ResponseEntity.ok(actions);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/mjcarvajalq/sales_metrics_api/controllers/UserController.java
+++ b/src/main/java/com/mjcarvajalq/sales_metrics_api/controllers/UserController.java
@@ -1,0 +1,23 @@
+package com.mjcarvajalq.sales_metrics_api.controllers;
+
+import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionDTO;
+import com.mjcarvajalq.sales_metrics_api.services.OutreachActionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final OutreachActionService outreachActionService;
+
+    @GetMapping("/{userId}/actions")
+    public ResponseEntity<List<OutreachActionDTO>> getUserActions(@PathVariable Long userId) {
+        List<OutreachActionDTO> actions = outreachActionService.getActionsByUserId(userId);
+        return ResponseEntity.ok(actions);
+    }
+}


### PR DESCRIPTION
   ## Overview
   This PR addresses issue #5 by separating the user-specific actions endpoint from the general actions endpoint for better separation of concerns.

   **Note: This PR should be merged after issue #4 (DTO pattern) is completed and merged.**

   ## Changes Made
   - **Modified `OutreachActionController`**: Removed optional `userId` parameter from `GET /api/actions` endpoint - now only returns all actions
   - **Created `UserController`**: New controller with dedicated endpoint `GET /api/users/{userId}/actions` for user-specific actions  
   - **Improved API design**: Better separation of concerns with user-specific operations in their own controller
   - **Consistent responses**: Both endpoints now return `ResponseEntity` for consistent HTTP responses

   ## API Endpoints After Changes
   - `GET /api/actions` - Returns all outreach actions (no filtering)
   - `GET /api/users/{userId}/actions` - Returns actions for a specific user
   - All other existing endpoints remain unchanged

   ## Testing
   - ✅ All existing tests pass
   - ✅ Manually tested both endpoints with Postman
   - ✅ Application starts successfully
   - ✅ Database seeding works correctly

   ## Dependencies
   - Depends on issue #4 (DTO pattern) being merged first
   - Should be merged after issue #4 is completed

   Resolves #5