### PR TITLE
Refactor: Improve Response Pattern - Replace DTO with Response Classes

### DIFF
--- a/src/main/java/com/mjcarvajalq/sales_metrics_api/controllers/OutreachActionController.java
+++ b/src/main/java/com/mjcarvajalq/sales_metrics_api/controllers/OutreachActionController.java
@@ -2,7 +2,7 @@ package com.mjcarvajalq.sales_metrics_api.controllers;
 
 import com.mjcarvajalq.sales_metrics_api.dto.CreateOutreachActionRequest;
 import com.mjcarvajalq.sales_metrics_api.dto.CreateOutreachActionResponse;
-import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionDTO;
+import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionResponse;
 import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionDetailResponse;
 import com.mjcarvajalq.sales_metrics_api.services.OutreachActionService;
 import jakarta.validation.Valid;
@@ -31,8 +31,8 @@ public class OutreachActionController {
     }
 
     @GetMapping
-    public ResponseEntity<List<OutreachActionDTO>> getAllActions() {
-        List<OutreachActionDTO> actions = outreachActionService.getAllActions();
+    public ResponseEntity<List<OutreachActionResponse>> getAllActions() {
+        List<OutreachActionResponse> actions = outreachActionService.getAllActions();
         return ResponseEntity.ok(actions);
     }
 

--- a/src/main/java/com/mjcarvajalq/sales_metrics_api/controllers/UserController.java
+++ b/src/main/java/com/mjcarvajalq/sales_metrics_api/controllers/UserController.java
@@ -1,6 +1,6 @@
 package com.mjcarvajalq.sales_metrics_api.controllers;
 
-import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionDTO;
+import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionResponse;
 import com.mjcarvajalq.sales_metrics_api.services.OutreachActionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,8 +16,8 @@ public class UserController {
     private final OutreachActionService outreachActionService;
 
     @GetMapping("/{userId}/actions")
-    public ResponseEntity<List<OutreachActionDTO>> getUserActions(@PathVariable Long userId) {
-        List<OutreachActionDTO> actions = outreachActionService.getActionsByUserId(userId);
+    public ResponseEntity<List<OutreachActionResponse>> getUserActions(@PathVariable Long userId) {
+        List<OutreachActionResponse> actions = outreachActionService.getActionsByUserId(userId);
         return ResponseEntity.ok(actions);
     }
 }

--- a/src/main/java/com/mjcarvajalq/sales_metrics_api/dto/OutreachActionResponse.java
+++ b/src/main/java/com/mjcarvajalq/sales_metrics_api/dto/OutreachActionResponse.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class OutreachActionDTO {
+public class OutreachActionResponse {
 
     private Long userId; // To associate this action with a user
     private ActionType type;

--- a/src/main/java/com/mjcarvajalq/sales_metrics_api/mappers/OutreachActionMapper.java
+++ b/src/main/java/com/mjcarvajalq/sales_metrics_api/mappers/OutreachActionMapper.java
@@ -2,7 +2,7 @@ package com.mjcarvajalq.sales_metrics_api.mappers;
 
 import com.mjcarvajalq.sales_metrics_api.dto.CreateOutreachActionRequest;
 import com.mjcarvajalq.sales_metrics_api.dto.CreateOutreachActionResponse;
-import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionDTO;
+import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionResponse;
 import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionDetailResponse;
 import com.mjcarvajalq.sales_metrics_api.model.OutreachAction;
 import com.mjcarvajalq.sales_metrics_api.model.User;
@@ -16,9 +16,7 @@ import java.util.List;
 public interface OutreachActionMapper {
 
     @Mapping(target = "userId", source = "user.id")
-    OutreachActionDTO toDTO(OutreachAction entity);
-
-    List<OutreachActionDTO> toDTOList(List<OutreachAction> entities);
+    OutreachActionResponse toResponse(OutreachAction entity);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "user", source = "user")

--- a/src/main/java/com/mjcarvajalq/sales_metrics_api/services/OutreachActionService.java
+++ b/src/main/java/com/mjcarvajalq/sales_metrics_api/services/OutreachActionService.java
@@ -2,15 +2,15 @@ package com.mjcarvajalq.sales_metrics_api.services;
 
 import com.mjcarvajalq.sales_metrics_api.dto.CreateOutreachActionRequest;
 import com.mjcarvajalq.sales_metrics_api.dto.CreateOutreachActionResponse;
-import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionDTO;
+import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionResponse;
 import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionDetailResponse;
 
 import java.util.List;
 
 public interface OutreachActionService {
     CreateOutreachActionResponse saveAction (CreateOutreachActionRequest request);
-    List<OutreachActionDTO> getAllActions();
-    List<OutreachActionDTO> getActionsByUserId(Long userId);
+    List<OutreachActionResponse> getAllActions();
+    List<OutreachActionResponse> getActionsByUserId(Long userId);
     OutreachActionDetailResponse getActionById(Long id);
 
 }

--- a/src/main/java/com/mjcarvajalq/sales_metrics_api/services/OutreachActionServiceImpl.java
+++ b/src/main/java/com/mjcarvajalq/sales_metrics_api/services/OutreachActionServiceImpl.java
@@ -1,7 +1,8 @@
 package com.mjcarvajalq.sales_metrics_api.services;
 import com.mjcarvajalq.sales_metrics_api.dto.CreateOutreachActionRequest;
 import com.mjcarvajalq.sales_metrics_api.dto.CreateOutreachActionResponse;
-import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionDTO;
+import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionResponse;
+import java.util.stream.Collectors;
 import com.mjcarvajalq.sales_metrics_api.dto.OutreachActionDetailResponse;
 import com.mjcarvajalq.sales_metrics_api.exceptions.OutreachActionNotFoundException;
 import com.mjcarvajalq.sales_metrics_api.exceptions.UserNotFoundException;
@@ -41,15 +42,19 @@ public class OutreachActionServiceImpl implements OutreachActionService{
     }
 
     @Override
-    public List<OutreachActionDTO> getAllActions() {
+    public List<OutreachActionResponse> getAllActions() {
         List<OutreachAction> actions = outreachActionRepository.findAll();
-        return outreachActionMapper.toDTOList(actions);
+        return actions.stream()
+                      .map(outreachActionMapper::toResponse)
+                      .collect(Collectors.toList());
     }
 
     @Override
-    public List<OutreachActionDTO> getActionsByUserId(Long userId) {
+    public List<OutreachActionResponse> getActionsByUserId(Long userId) {
         List<OutreachAction> actions = outreachActionRepository.findByUserId(userId);
-        return outreachActionMapper.toDTOList(actions);
+        return actions.stream()
+                      .map(outreachActionMapper::toResponse)
+                      .collect(Collectors.toList());
     }
     @Override
     public OutreachActionDetailResponse getActionById(Long id){


### PR DESCRIPTION
   ## 🎯 Purpose
   This PR addresses feedback about using proper Response classes instead of DTOs in controller endpoints for better API design and semantic clarity.

   ## 📋 Changes Made
   - **Renamed** `OutreachActionDTO` to `OutreachActionResponse`
   - **Updated** all controllers to use `OutreachActionResponse` instead of DTO
   - **Modified** service layer and mapper to support the new response pattern
   - **Improved** API response consistency

   ## 🔍 Files Changed  
   - `OutreachActionController.java` - Updated to use OutreachActionResponse
   - `UserController.java` - Updated to use OutreachActionResponse  
   - `OutreachActionService.java` - Updated interface signatures
   - `OutreachActionServiceImpl.java` - Updated implementation
   - `OutreachActionMapper.java` - Updated mapping methods
   - `OutreachActionDTO.java` → `OutreachActionResponse.java` (renamed)

   ## ✅ Testing
   - [x] Project compiles successfully
   - [x] All existing functionality preserved
   - [x] Consistent naming pattern with other Response classes

   ## 📝 Notes
   This change follows the feedback about using `OutreachActionResponse` instead of DTO in controllers, making the API design more semantic and consistent with the existing `CreateOutreachActionResponse` and `OutreachActionDetailResponse` patterns.