### PR TITLE
Integrate Liquibase for database schema versioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Liquibase: Database schema versioning and migration -->
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
+
         <!-- ================================ -->
         <!-- VALIDATION DEPENDENCIES         -->
         <!-- ================================ -->

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,9 +8,13 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JPA Configuration
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+# Liquibase Configuration
+spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
+spring.liquibase.enabled=true
 
 # Connection Pool Configuration
 spring.datasource.hikari.maximum-pool-size=20

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+    <!-- Include individual changelog files -->
+    <include file="db/changelog/v1.0/001-create-users-table.xml"/>
+    <include file="db/changelog/v1.0/002-create-outreach-action-table.xml"/>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v1.0/001-create-users-table.xml
+++ b/src/main/resources/db/changelog/v1.0/001-create-users-table.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+    <changeSet id="001-create-users-table" author="mjcarvajal">
+        <comment>Create users table for storing user information</comment>
+        
+        <createTable tableName="users">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="email" type="VARCHAR(255)">
+                <constraints nullable="true" unique="true"/>
+            </column>
+        </createTable>
+        
+        <rollback>
+            <dropTable tableName="users"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v1.0/002-create-outreach-action-table.xml
+++ b/src/main/resources/db/changelog/v1.0/002-create-outreach-action-table.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+    <changeSet id="002-create-outreach-action-table" author="mjcarvajal">
+        <comment>Create outreach_action table for storing sales outreach activities</comment>
+        
+        <createTable tableName="outreach_action">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="type" type="VARCHAR(50)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="date_time" type="TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+            <column name="notes" type="TEXT">
+                <constraints nullable="true"/>
+            </column>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+        
+        <!-- Add foreign key constraint -->
+        <addForeignKeyConstraint
+            baseTableName="outreach_action"
+            baseColumnNames="user_id"
+            constraintName="fk_outreach_action_user_id"
+            referencedTableName="users"
+            referencedColumnNames="id"/>
+        
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="outreach_action" constraintName="fk_outreach_action_user_id"/>
+            <dropTable tableName="outreach_action"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -15,3 +15,6 @@ spring.jpa.show-sql=false
 # H2 Console (available in tests if needed)
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
+
+# Liquibase Configuration for Testing
+spring.liquibase.enabled=false


### PR DESCRIPTION
🎯 **Purpose**  
This PR integrates Liquibase to manage database schema changes and version control, preparing for production database management.

📋 **Changes Made**  
- Add Liquibase dependency to pom.xml
- Create changelog directory structure (db/changelog/v1.0/)
- Create master changelog file (db.changelog-master.xml)
- Create individual table changelogs for users and outreach_action tables
- Configure Liquibase properties in application.properties
- Change JPA ddl-auto from create-drop to none
- Disable Liquibase for tests to maintain H2 fast testing
- Add rollback instructions for all changesets

🔍 **Files Changed**  
- `pom.xml` - Added Liquibase dependency
- `src/main/resources/application.properties` - Added Liquibase configuration, disabled JPA DDL
- `src/test/resources/application-test.properties` - Disabled Liquibase for tests
- `src/main/resources/db/changelog/db.changelog-master.xml` - Master changelog file
- `src/main/resources/db/changelog/v1.0/001-create-users-table.xml` - Users table definition
- `src/main/resources/db/changelog/v1.0/002-create-outreach-action-table.xml` - OutreachAction table with FK

✅ **Testing**  
- [x] Tests pass using H2 with Liquibase disabled
- [x] Liquibase configuration properly set up
- [x] Schema definitions match current JPA entities
- [x] Rollback instructions included for all changesets

📝 **Notes**  
- **Depends on PostgreSQL branch** - This PR should be merged after #16
- Database schema creation now managed by Liquibase instead of JPA
- PostgreSQL integration testing will be completed in the Docker Compose setup
- All changesets include proper rollback instructions for safe deployments

**Base Branch:** `feature/add-postgresql-dependency`